### PR TITLE
Apply form generics also to SettingsForm methods

### DIFF
--- a/gomint-api/src/main/java/io/gomint/entity/EntityPlayer.java
+++ b/gomint-api/src/main/java/io/gomint/entity/EntityPlayer.java
@@ -151,10 +151,10 @@ public interface EntityPlayer extends EntityHuman {
      * Set the server settings form
      *
      * @param form which will be set as the new settings form
-     * @param <T>  type of return value from the response
+     * @param <R>  type of return value from the response
      * @return form listener to attaching for response
      */
-    <T> FormListener<T> setSettingsForm( Form form );
+    <R> FormListener<R> setSettingsForm( Form<R> form );
 
     /**
      * Remove the current stored settings form

--- a/gomint-server/src/main/java/io/gomint/server/entity/EntityPlayer.java
+++ b/gomint-server/src/main/java/io/gomint/server/entity/EntityPlayer.java
@@ -1315,14 +1315,7 @@ public class EntityPlayer extends EntityHuman implements io.gomint.entity.Entity
 
         this.forms.put( formId, implForm );
 
-        io.gomint.server.gui.FormListener formListener = null;
-        if ( form instanceof ButtonList ) {
-            formListener = new io.gomint.server.gui.FormListener<String>();
-        } else if ( form instanceof Modal ) {
-            formListener = new io.gomint.server.gui.FormListener<Boolean>();
-        } else {
-            formListener = new io.gomint.server.gui.FormListener<FormResponse>();
-        }
+        io.gomint.server.gui.FormListener formListener = new io.gomint.server.gui.FormListener<R>();
 
         this.formListeners.put( formId, formListener );
 
@@ -1337,24 +1330,17 @@ public class EntityPlayer extends EntityHuman implements io.gomint.entity.Entity
     }
 
     @Override
-    public <T> FormListener<T> setSettingsForm( Form form ) {
+    public <R> FormListener<R> setSettingsForm( Form<R> form ) {
         if ( this.serverSettingsForm != -1 ) {
             this.removeSettingsForm();
         }
 
         int formId = this.formId++;
-        io.gomint.server.gui.Form implForm = (io.gomint.server.gui.Form) form;
+        io.gomint.server.gui.Form<R> implForm = (io.gomint.server.gui.Form<R>) form;
 
         this.forms.put( formId, implForm );
 
-        io.gomint.server.gui.FormListener formListener = null;
-        if ( form instanceof ButtonList ) {
-            formListener = new io.gomint.server.gui.FormListener<String>();
-        } else if ( form instanceof Modal ) {
-            formListener = new io.gomint.server.gui.FormListener<Boolean>();
-        } else {
-            formListener = new io.gomint.server.gui.FormListener<FormResponse>();
-        }
+        io.gomint.server.gui.FormListener<R> formListener = new io.gomint.server.gui.FormListener<R>();
 
         this.formListeners.put( formId, formListener );
         this.serverSettingsForm = formId;


### PR DESCRIPTION
Also remove a useless if in implementation of these form methods, because generics don't change a class and are syntactic sugar and not enforced/present at runtime.