### PR TITLE
Re-add proxyCount to EventProxy className

### DIFF
--- a/gomint-server/src/main/java/io/gomint/server/event/EventHandlerMethod.java
+++ b/gomint-server/src/main/java/io/gomint/server/event/EventHandlerMethod.java
@@ -12,7 +12,6 @@ import io.gomint.event.EventHandler;
 import io.gomint.event.EventListener;
 import io.gomint.server.maintenance.ReportUploader;
 import io.gomint.server.plugin.PluginClassloader;
-
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -22,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author BlackyPaw
@@ -30,6 +30,8 @@ import java.util.Objects;
 class EventHandlerMethod implements Comparable<EventHandlerMethod> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventHandlerMethod.class);
+
+    private static final AtomicInteger PROXY_COUNT = new AtomicInteger(0);
 
     private final EventHandler annotation;
     private EventProxy proxy;
@@ -54,7 +56,7 @@ class EventHandlerMethod implements Comparable<EventHandlerMethod> {
                 ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 
                 String listenerClassName = instance.getClass().getName().replace(".", "/");
-                String className = listenerClassName + "Proxy";
+                String className = listenerClassName + "Proxy" + PROXY_COUNT.incrementAndGet();
                 String eventClassName = method.getParameterTypes()[0].getName().replace(".", "/");
 
                 // Define the class


### PR DESCRIPTION
This PR fixes a bug when registering a listener with multiple @EventHandler-methods.
So far, GoMint created a EventProxy class for every @EventHandler-method, using the listener class name + "Proxy" as class name for the proxy. This didn't work for listeners with multiple @EventHandler-methods, GoMint tried to create the same EventProxy class multiple times. Exceptions like this occured: https://just-paste.it/OFp06Nwyhy/
I now fixed this by re-adding the proxyCount, this has been tested and works.
As this got removed by some of the recent commits (https://github.com/gomint/gomint/commit/d90eacb530fb218e868b4800417f049e593ac11d#diff-c3c9a8af3ebb7e523253c8c835c077e7), this might not be the prettiest solution, a count per listener may be better, or a completely different approach.