### PR TITLE
Expose player address to API users

### DIFF
--- a/gomint-api/src/main/java/io/gomint/entity/EntityPlayer.java
+++ b/gomint-api/src/main/java/io/gomint/entity/EntityPlayer.java
@@ -25,6 +25,7 @@ import io.gomint.world.ParticleData;
 import io.gomint.world.Sound;
 import io.gomint.world.SoundData;
 
+import java.net.InetSocketAddress;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
@@ -350,6 +351,13 @@ public interface EntityPlayer extends EntityHuman {
      * @return device information from this player
      */
     DeviceInfo getDeviceInfo();
+
+    /**
+     * Get the socket address from the connection of this player
+     *
+     * @return the socket address of this player
+     */
+    InetSocketAddress getAddress();
 
     /**
      * Disptach a command for this player

--- a/gomint-server/src/main/java/io/gomint/server/entity/EntityPlayer.java
+++ b/gomint-server/src/main/java/io/gomint/server/entity/EntityPlayer.java
@@ -67,6 +67,7 @@ import it.unimi.dsi.fastutil.objects.Object2ByteOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -1629,6 +1630,11 @@ public class EntityPlayer extends EntityHuman implements io.gomint.entity.Entity
     @Override
     public DeviceInfo getDeviceInfo() {
         return this.connection.getDeviceInfo();
+    }
+
+    @Override
+    public InetSocketAddress getAddress() {
+        return this.connection.getConnection().getAddress();
     }
 
     @Override


### PR DESCRIPTION
This PR adds a getAddress()-method to the EntityPlayer interface.
The player address is a very basic info about the player and might be useful in plugins which might want to ban a player by ip, or just want to display information about the player.