### PR TITLE
Allow plugin module read access to dependant plugins which does not contain a module info

### DIFF
--- a/gomint-api/pom.xml
+++ b/gomint-api/pom.xml
@@ -99,6 +99,9 @@
                             <head>API stability level:</head>
                         </tag>
                     </tags>
+                    <sourceFileExcludes>
+                        <sourceFileExclude>module-info.java</sourceFileExclude>
+                    </sourceFileExcludes>
                 </configuration>
                 <executions>
                     <execution>

--- a/gomint-server/src/main/java/io/gomint/server/plugin/PluginMeta.java
+++ b/gomint-server/src/main/java/io/gomint/server/plugin/PluginMeta.java
@@ -34,6 +34,7 @@ public class PluginMeta {
 
     // Module stuff
     private String moduleName;
+    private boolean hasModuleInfo;
     private Set<String> packages;
     private Set<File> moduleDependencies;
 
@@ -111,6 +112,14 @@ public class PluginMeta {
 
     public void setModuleName(String moduleName) {
         this.moduleName = moduleName;
+    }
+
+    public boolean hasModuleInfo() {
+        return hasModuleInfo;
+    }
+
+    public void setHasModuleInfo(boolean hasModuleInfo) {
+        this.hasModuleInfo = hasModuleInfo;
     }
 
     public Set<String> getPackages() {


### PR DESCRIPTION
Currently, it's the case that plugins aren't allowed to read from dependent plugins (for example to implement/extend a class) because both of these classes are in different modules. This may cause an error looking like: 

```java.lang.IllegalAccessError: superinterface check failed: class systems.reformcloud.reformcloud2.signs.util.sign.config.SignConfig (in module signs) cannot access class systems.reformcloud.reformcloud2.executor.api.network.SerializableObject (in module executor) because module signs does not read module executor```

This may cause plugin to work not correctly, or they are just unable to be implemented correctly (like vault on bukkit - it's common that you extend for example the `Chat` to integrate your permission system into it). Another reason why this change is needed is that you cannot use the cli-options from java like `--add-opens` because the module of the dependent plugin is lazily initialized.

So what this pull request simply do is:
 * First it collects all (soft-) dependant plugins of the current plugin load which are loaded
 * Then it checks if the plugin does specifiy a module info. If so, it will not include it into the list of modules which are needed to grant access to
 * After the collect the server will grant read access to the dependent module using the associated `ModuleLayerController`