### PR TITLE
Check if plugin depends are null before collecting dependant modules

### DIFF
--- a/gomint-server/src/main/java/io/gomint/server/plugin/SimplePluginManager.java
+++ b/gomint-server/src/main/java/io/gomint/server/plugin/SimplePluginManager.java
@@ -321,7 +321,7 @@ public class SimplePluginManager implements PluginManager, EventCaller {
     }
 
     private Collection<Module> collectDependantModules(PluginMeta meta) {
-        if (meta.hasModuleInfo()) {
+        if (meta.hasModuleInfo() || meta.getDepends() == null || meta.getSoftDepends() == null) {
             return Set.of();
         }
 


### PR DESCRIPTION
If a plugin does not have any depends, the following error always occurs and the plugin does not start.
```
[14.10 23:04:44.419] INFO: [GoMint-1] java.lang.NullPointerException: null
[14.10 23:04:44.419] INFO: [GoMint-1]   at io.gomint.server.plugin.SimplePluginManager.collectDependantModules(SimplePluginManager.java:329) ~[GoMint.jar:?]
[14.10 23:04:44.419] INFO: [GoMint-1]   at io.gomint.server.plugin.SimplePluginManager.loadPlugin(SimplePluginManager.java:277) ~[GoMint.jar:?]
[14.10 23:04:44.419] INFO: [GoMint-1]   at io.gomint.server.plugin.SimplePluginManager.loadPlugins(SimplePluginManager.java:170) ~[GoMint.jar:?]
[14.10 23:04:44.419] INFO: [GoMint-1]   at io.gomint.server.GoMintServer.<init>(GoMintServer.java:244) ~[GoMint.jar:?]
[14.10 23:04:44.419] INFO: [GoMint-1]   at io.gomint.server.Bootstrap.main(Bootstrap.java:85) ~[GoMint.jar:?]
[14.10 23:04:44.419] INFO: [GoMint-1]   at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
[14.10 23:04:44.419] INFO: [GoMint-1]   at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
[14.10 23:04:44.419] INFO: [GoMint-1]   at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
[14.10 23:04:44.419] INFO: [GoMint-1]   at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
[14.10 23:04:44.419] INFO: [GoMint-1]   at de.dytanic.cloudnet.wrapper.Wrapper.lambda$startApplication$5(Wrapper.java:449) ~[wrapper.jar:3.4.0-SNAPSHOT-84f8f2a]
[14.10 23:04:44.419] INFO: [GoMint-1]   at java.lang.Thread.run(Thread.java:834) [?:?]
```