### PR TITLE
Add support for new MAC M1 (aarch64 on darwin)

### DIFF
--- a/gomint-server/pom.xml
+++ b/gomint-server/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>io.gomint</groupId>
             <artifactId>crypto</artifactId>
-            <version>1.3.1-SNAPSHOT</version>
+            <version>1.4.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>io.gomint</groupId>
             <artifactId>leveldb-jni</artifactId>
-            <version>1.4.0-SNAPSHOT</version>
+            <version>1.5.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/gomint-server/src/main/java/io/gomint/server/world/leveldb/LevelDBWorldAdapter.java
+++ b/gomint-server/src/main/java/io/gomint/server/world/leveldb/LevelDBWorldAdapter.java
@@ -9,7 +9,7 @@ package io.gomint.server.world.leveldb;
 
 import com.google.common.io.Files;
 import io.gomint.leveldb.DB;
-import io.gomint.leveldb.NativeLoader;
+import io.gomint.leveldb.LibraryLoader;
 import io.gomint.leveldb.WriteBatch;
 import io.gomint.math.BlockPosition;
 import io.gomint.math.Location;
@@ -66,7 +66,7 @@ public class LevelDBWorldAdapter extends WorldAdapter {
     private static final Logger LOGGER = LoggerFactory.getLogger(LevelDBWorldAdapter.class);
 
     static {
-        if (!NativeLoader.load()) {
+        if (!LibraryLoader.load()) {
             System.out.println("Could not load native leveldb. Please be sure you have a supported OS installed");
             System.exit(-1);
         }


### PR DESCRIPTION
Please ensure that you use at least openjdk 15 from brew for this one. All other installations use rosetta 2 and are amd64 which is not supported for darwin