### PR TITLE
According to JEPS-261 (https://openjdk.java.net/jeps/261) a container…

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ mvn clean install
 ```
 
 ## 🚀 Developer setup
-You need to run compilation at least once since there is a code generator configured. Once you have done that you can add `io.gomint.server.Bootstrap` as a runner. That runner needs custom options for Netty `--add-opens java.base/java.nio=io.netty.common --add-exports java.base/jdk.internal.misc=io.netty.common`.
+You need to run compilation at least once since there is a code generator configured. Once you have done that you can add `io.gomint.server.Bootstrap` as a runner. 
+That runner needs custom options for Netty `--add-opens java.base/java.nio=io.netty.common --add-exports java.base/jdk.internal.misc=io.netty.common --add-modules ALL-DEFAULT`.
 
 If not properly configured you will see this error when the first connection arrives:
 

--- a/release/start.cmd
+++ b/release/start.cmd
@@ -1,2 +1,2 @@
 @echo off
-java -Dio.netty.buffer.checkBounds=false --add-opens java.base/java.nio=io.netty.common --add-exports java.base/jdk.internal.misc=io.netty.common -p modules -m gomint.server/io.gomint.server.Bootstrap
+java -Dio.netty.buffer.checkBounds=false --add-modules ALL-DEFAULT --add-opens java.base/java.nio=io.netty.common --add-exports java.base/jdk.internal.misc=io.netty.common -p modules -m gomint.server/io.gomint.server.Bootstrap

--- a/release/start.sh
+++ b/release/start.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-java -Dio.netty.buffer.checkBounds=false --add-opens java.base/java.nio=io.netty.common \
+java -Dio.netty.buffer.checkBounds=false --add-modules ALL-DEFAULT --add-opens java.base/java.nio=io.netty.common \
  --add-exports java.base/jdk.internal.misc=io.netty.common -p modules -m gomint.server/io.gomint.server.Bootstrap


### PR DESCRIPTION
… host (in this case gomint) should load ALL-DEFAULT modules so containers (plugins) can depend on them. This fixes #709