### PR TITLE
Update crypto, leveldbjni and oshi to get rid of multiple crashes on non AESNI enabled CPUs

### DIFF
--- a/gomint-server/pom.xml
+++ b/gomint-server/pom.xml
@@ -39,13 +39,7 @@
         <dependency>
             <groupId>io.gomint</groupId>
             <artifactId>crypto</artifactId>
-            <version>1.4.0-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.oshi</groupId>
-            <artifactId>oshi-core</artifactId>
-            <version>3.5.0</version>
+            <version>1.4.3-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -120,7 +114,7 @@
         <dependency>
             <groupId>io.gomint</groupId>
             <artifactId>leveldb-jni</artifactId>
-            <version>1.5.0-SNAPSHOT</version>
+            <version>1.5.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/gomint-server/src/main/java/io/gomint/server/maintenance/ReportUploader.java
+++ b/gomint-server/src/main/java/io/gomint/server/maintenance/ReportUploader.java
@@ -67,9 +67,9 @@ public final class ReportUploader {
 
         // Ask for OS and CPU info
         SystemInfo systemInfo = new SystemInfo();
-        this.context.addExtra("system.os", systemInfo.getOperatingSystem().getFamily() + " [" + systemInfo.getOperatingSystem().getVersion().getVersion() + "]");
+        this.context.addExtra("system.os", systemInfo.getOperatingSystem().getFamily() + " [" + systemInfo.getOperatingSystem().getVersionInfo().getVersion() + "]");
         this.context.addExtra("system.memory", getCount(systemInfo.getHardware().getMemory().getTotal()));
-        this.context.addExtra("system.cpu", systemInfo.getHardware().getProcessor().getName());
+        this.context.addExtra("system.cpu", systemInfo.getHardware().getProcessor().getProcessorIdentifier().getName());
 
         // Basic process stats
         this.context.addExtra("system.process_memory_total", getCount(Runtime.getRuntime().totalMemory()));

--- a/gomint-server/src/main/java/module-info.java
+++ b/gomint-server/src/main/java/module-info.java
@@ -34,7 +34,7 @@ module gomint.server {
     requires com.google.common;
     requires org.apache.commons.io;
     requires json.simple;
-    requires oshi.core;
+    requires com.github.oshi;
     requires jsr305;
     requires jline.reader;
     requires jline.terminal;


### PR DESCRIPTION
Crypto had a compile time condition for AESNI. This was fine as long as the compile cpu has the same instruction sets as the runtime one. This was not always the case. I had received bugreports over discord of a i5-6400 which crashes because it doesn't have AESNI (ILLEGAL_INSTRUCTION on AESKEYGEN).